### PR TITLE
Add API compatibility with django-pylibmc

### DIFF
--- a/django_bmemcached/memcached.py
+++ b/django_bmemcached/memcached.py
@@ -13,13 +13,16 @@ class BMemcached(memcached.BaseMemcachedCache):
             params['OPTIONS'] = {}
 
         username = params['OPTIONS'].get('username',
-            os.environ.get('MEMCACHE_USERNAME', None))
+            params.get('USERNAME',
+            os.environ.get('MEMCACHE_USERNAME')))
 
         if username:
             params['OPTIONS']['username'] = username
 
         password = params['OPTIONS'].get('password',
-            os.environ.get('MEMCACHE_PASSWORD', None))
+            params.get('PASSWORD',
+            os.environ.get('MEMCACHE_PASSWORD')))
+
         if password:
             params['OPTIONS']['password'] = password
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -27,6 +27,13 @@ class TestWithExplicitAuth(unittest.TestCase):
         self.assertEqual(self.client._client, self.client._cache)
 
 
+class TestWithTopLevelAuthParams(TestWithExplicitAuth):
+    def setUp(self):
+        self.client = django_bmemcached.BMemcached(('127.0.0.1:11211', ),
+            {'USERNAME': 'user', 'PASSWORD': 'password'})
+
+
+
 class TestWithEnvironmentAuth(TestWithExplicitAuth):
     def setUp(self):
         os.environ['MEMCACHE_SERVERS'] = '127.0.0.1'


### PR DESCRIPTION
Django-pylibmc takes authentication parameters as keys on the main
cache config dictionary, rather then the `OPTIONS` dict. By adding
support for this API it makes it easier to swap between the backends.

Obviously the existing API is still supported so there should be no
backwards compatibility issues.
