### PR TITLE
Use relative import in __init__ (Fix Python 3 Support)

### DIFF
--- a/django_bmemcached/__init__.py
+++ b/django_bmemcached/__init__.py
@@ -1,1 +1,1 @@
-from memcached import BMemcached
+from .memcached import BMemcached


### PR DESCRIPTION
Currently python-binary-memcached do not support Python3 but with this small fix when other package is fixed this will have Python 3 support.
