### PR TITLE
Don't disconnect from memcache on every request

### DIFF
--- a/django_bmemcached/memcached.py
+++ b/django_bmemcached/memcached.py
@@ -26,6 +26,11 @@ class BMemcached(memcached.BaseMemcachedCache):
 
         super(BMemcached, self).__init__(server, params, library=bmemcached, value_not_found_exception=ValueError)
 
+    def close(self, **kwargs):
+        # Override base behavior of disconnecting from memcache on every HTTP request.
+        # This method is, in practice, only called by Django on the request_finished signal
+        pass
+
     @property
     def _cache(self):
         client = getattr(self, '_client', None)


### PR DESCRIPTION
Currently, Django disconnects from the cache on at the end of every HTTP request. This is a significant performance problem as it mangifies the number of round trip times (each connection requires a VERSION command, and if authenticating a LIST_MECHS and an AUTH command before any real work can be done) and incurs the cost of TCP startup every time.

There has been a long and slow push to get this fixed upstream in Django (https://code.djangoproject.com/ticket/11331, https://github.com/django/django/pull/4866), but it's a simple enough fix to do at the higher level library.