### PR TITLE
Fix incompabilities between Django memcache base class

### DIFF
--- a/django_bmemcached/memcached.py
+++ b/django_bmemcached/memcached.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from django.core.cache.backends import memcached
+from django.core.cache.backends.base import DEFAULT_TIMEOUT
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
First of all, thank you for making this library.

I have spotted two issues when using the cache class in Django. Both have to do with the data types that the base django memcache class uses, and the ones that python-binary-memcached expects. I fix it by overriding

- get_many, and
- set_many

and adding plenty of comments/stack traces that I encountered in production. Without this extensions such as django-memoize will break due to the heavy use of get/set many.

If you think there is a test case I could contribute / documentation that I can improve, please let me know.